### PR TITLE
Add arrow navigation for command history

### DIFF
--- a/src/main/java/seedu/address/commons/util/QueueUtil.java
+++ b/src/main/java/seedu/address/commons/util/QueueUtil.java
@@ -1,0 +1,87 @@
+package seedu.address.commons.util;
+
+public class QueueUtil<E> implements RandomAccessQueue<E> {
+    private final int capacity;
+    private final E[] elements;
+    private int head;
+    private int tail;
+    private int size;
+
+    /**
+     * Current traversal index. By default, it is at the tail of the queue.
+     */
+    private int cur;
+
+    /**
+     * Constructs a {@code QueueUtil} with the given capacity.
+     */
+    public QueueUtil(int capacity) {
+        this.capacity = capacity;
+        @SuppressWarnings("unchecked")
+        E[] temp = (E[]) new Object[capacity];
+        this.elements = temp;
+        this.head = 0;
+        this.tail = 0;
+        this.size = 0;
+        this.cur = 0;
+    }
+
+    @Override
+    public void addLast(E e) {
+        if (size == capacity) {
+            head = (head + 1) % capacity;
+        } else {
+            size++;
+        }
+        elements[tail] = e;
+        tail = (tail + 1) % capacity;
+        cur = tail;
+    }
+
+    @Override
+    public E pollFirst() {
+        if (size == 0) {
+            return null;
+        }
+        E result = elements[head];
+        head = (head + 1) % capacity;
+        size--;
+        return result;
+    }
+
+    @Override
+    public E get(int index) {
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+        }
+        return elements[(head + index) % capacity];
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public E traverseUp() {
+        if (cur == head) {
+            return null;
+        }
+        cur = (cur - 1 + capacity) % capacity;
+        return elements[cur];
+    }
+
+    @Override
+    public E traverseDown() {
+        if (cur == tail) {
+            return null;
+        }
+        cur = (cur + 1) % capacity;
+        return elements[cur];
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size == 0;
+    }
+}

--- a/src/main/java/seedu/address/commons/util/QueueUtil.java
+++ b/src/main/java/seedu/address/commons/util/QueueUtil.java
@@ -1,5 +1,10 @@
 package seedu.address.commons.util;
 
+/**
+ * Represents a queue that allows random access to its elements.
+ *
+ * @param <E> the type of elements in the queue
+ */
 public class QueueUtil<E> implements RandomAccessQueue<E> {
     private final int capacity;
     private final E[] elements;

--- a/src/main/java/seedu/address/commons/util/RandomAccessQueue.java
+++ b/src/main/java/seedu/address/commons/util/RandomAccessQueue.java
@@ -2,6 +2,8 @@ package seedu.address.commons.util;
 
 /**
  * Represents a queue that allows random access to its elements.
+ *
+ * @param <E> the type of elements in the queue
  */
 public interface RandomAccessQueue<E> {
 

--- a/src/main/java/seedu/address/commons/util/RandomAccessQueue.java
+++ b/src/main/java/seedu/address/commons/util/RandomAccessQueue.java
@@ -1,0 +1,66 @@
+package seedu.address.commons.util;
+
+/**
+ * Represents a queue that allows random access to its elements.
+ */
+public interface RandomAccessQueue<E> {
+
+    /**
+     * Adds the specified element to the tail of the queue. If the queue is full,
+     * the oldest element will be removed from the head of the queue. Behavior is
+     * undefined if the queue has maximum capacity of 0.
+     *
+     * @param e the element to add
+     */
+    public void addLast(E e);
+
+    /**
+     * Retrieves and removes the head of this queue, or returns null if this queue
+     * is empty.
+     *
+     * @return the first element in the queue, or null if the queue is empty
+     */
+    public E pollFirst();
+
+    /**
+     * Returns the element at the specified index in the queue. The element at index
+     * 0 is the head of the queue, the element at index 1 is the next element in the
+     * queue, and so on.
+     *
+     * @param index the index of the element to return
+     * @return the element at the specified index
+     */
+    public E get(int index);
+
+    /**
+     * Returns the number of elements in the queue.
+     *
+     * @return the number of elements in the queue
+     */
+    public int size();
+
+    /**
+     * Traverses one step up towards the head to the next element in the queue and
+     * returns it. If the head of the queue is reached, returns null.
+     *
+     * @return the next element in the queue, or null if the head of the queue is
+     *         reached
+     */
+    public E traverseUp();
+
+    /**
+     * Traverses one step down towards the tail to the next element in the queue and
+     * returns it. If the tail of the queue is reached, returns null.
+     *
+     * @return the next element in the queue, or null if the tail of the queue is
+     *         reached
+     */
+    public E traverseDown();
+
+    /**
+     * Returns whether the queue is empty.
+     *
+     * @return true if the queue is empty, false otherwise
+     */
+    public boolean isEmpty();
+}

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -6,6 +6,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.inputhistory.UserInputHistory;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
@@ -16,10 +17,11 @@ import seedu.address.model.person.Person;
 public interface Logic {
     /**
      * Executes the command and returns the result.
+     *
      * @param commandText The command as entered by the user.
      * @return the result of the command execution.
      * @throws CommandException If an error occurs during command execution.
-     * @throws ParseException If an error occurs during parsing.
+     * @throws ParseException   If an error occurs during parsing.
      */
     CommandResult execute(String commandText) throws CommandException, ParseException;
 
@@ -47,4 +49,9 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the user input history.
+     */
+    UserInputHistory<String> getUserInputHistory();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -11,6 +11,8 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.inputhistory.UserInputHistory;
+import seedu.address.logic.inputhistory.UserInputHistoryManager;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -24,22 +26,25 @@ import seedu.address.storage.Storage;
 public class LogicManager implements Logic {
     public static final String FILE_OPS_ERROR_FORMAT = "Could not save data due to the following error: %s";
 
-    public static final String FILE_OPS_PERMISSION_ERROR_FORMAT =
-            "Could not save data to file %s due to insufficient permissions to write to the file or the folder.";
+    public static final String FILE_OPS_PERMISSION_ERROR_FORMAT = "Could not save data to file %s"
+            + " due to insufficient permissions to write to the file or the folder.";
 
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
+    private final UserInputHistory<String> userInputHistory;
 
     /**
-     * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
+     * Constructs a {@code LogicManager} with the given {@code Model} and
+     * {@code Storage}.
      */
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
         addressBookParser = new AddressBookParser();
+        userInputHistory = new UserInputHistoryManager();
     }
 
     @Override
@@ -84,5 +89,10 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public UserInputHistory<String> getUserInputHistory() {
+        return userInputHistory;
     }
 }

--- a/src/main/java/seedu/address/logic/inputhistory/UserInputHistory.java
+++ b/src/main/java/seedu/address/logic/inputhistory/UserInputHistory.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.inputhistory;
+
+/**
+ * Represents the history of user input.
+ *
+ * @param <T> The type of the user input.
+ */
+public interface UserInputHistory<T> {
+    /**
+     * Adds the given chat message to the chat history.
+     *
+     * @param chatMessage The chat message to be added to the chat history.
+     */
+    public void addChatToHistory(String chatMessage);
+
+    /**
+     * Returns true if there are chat messages in the chat history.
+     *
+     * @return True if there are chat messages in the chat history, false otherwise.
+     */
+    public boolean hasHistory();
+
+    /**
+     * Returns the previous chat message in the chat history.
+     *
+     * @return The previous chat message in the chat history.
+     */
+    public T getPreviousChat();
+
+    /**
+     * Returns the next chat message in the chat history.
+     *
+     * @return The next chat message in the chat history.
+     */
+    public T getNextChat();
+}

--- a/src/main/java/seedu/address/logic/inputhistory/UserInputHistoryManager.java
+++ b/src/main/java/seedu/address/logic/inputhistory/UserInputHistoryManager.java
@@ -10,7 +10,7 @@ public class UserInputHistoryManager implements UserInputHistory<String> {
     private static final int MAX_HISTORY_SIZE = 100;
 
     /**
-     * The history of user input. Implemented as a circular buffer of strings.
+     * The history of user input.
      */
     private final RandomAccessQueue<String> history; // not sure if String should be used
 

--- a/src/main/java/seedu/address/logic/inputhistory/UserInputHistoryManager.java
+++ b/src/main/java/seedu/address/logic/inputhistory/UserInputHistoryManager.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.inputhistory;
+
+import seedu.address.commons.util.QueueUtil;
+import seedu.address.commons.util.RandomAccessQueue;
+
+/**
+ * Represents the history of user input.
+ */
+public class UserInputHistoryManager implements UserInputHistory<String> {
+    private static final int MAX_HISTORY_SIZE = 100;
+
+    /**
+     * The history of user input. Implemented as a circular buffer of strings.
+     */
+    private final RandomAccessQueue<String> history; // not sure if String should be used
+
+    public UserInputHistoryManager() {
+        history = new QueueUtil<>(MAX_HISTORY_SIZE);
+    }
+
+    @Override
+    public void addChatToHistory(String chatMessage) {
+        history.addLast(chatMessage);
+    }
+
+    @Override
+    public boolean hasHistory() {
+        return !history.isEmpty();
+    }
+
+    @Override
+    public String getPreviousChat() {
+        return history.traverseUp();
+    }
+
+    @Override
+    public String getNextChat() {
+        return history.traverseDown();
+    }
+}

--- a/src/main/java/seedu/address/logic/inputhistory/UserInputHistoryManager.java
+++ b/src/main/java/seedu/address/logic/inputhistory/UserInputHistoryManager.java
@@ -28,6 +28,10 @@ public class UserInputHistoryManager implements UserInputHistory<String> {
         return !history.isEmpty();
     }
 
+    int size() {
+        return history.size();
+    }
+
     @Override
     public String getPreviousChat() {
         return history.traverseUp();

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,8 +1,12 @@
 package seedu.address.ui;
 
+import java.util.function.Supplier;
+import java.util.function.Consumer;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -17,6 +21,8 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
+    private Consumer<String> commandToHistorySaver = (commandText) -> {
+    };
 
     @FXML
     private TextField commandTextField;
@@ -27,8 +33,70 @@ public class CommandBox extends UiPart<Region> {
     public CommandBox(CommandExecutor commandExecutor) {
         super(FXML);
         this.commandExecutor = commandExecutor;
-        // calls #setStyleToDefault() whenever there is a change to the text of the command box.
+        // calls #setStyleToDefault() whenever there is a change to the text of the
+        // command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+    }
+
+    /**
+     * Creates a {@code CommandBox} with the given {@code CommandExecutor} and 2
+     * suppliers for the previous and next command.
+     *
+     * @param commandExecutor         The command executor.
+     * @param previousCommandSupplier The supplier for the previous command.
+     * @param nextCommandSupplier     The supplier for the next command.
+     * @param commandToHistorySaver   The consumer for saving the command to
+     *                                history.
+     */
+    public CommandBox(CommandExecutor commandExecutor, Supplier<String> previousCommandSupplier,
+            Supplier<String> nextCommandSupplier, Consumer<String> commandToHistorySaver) {
+        this(commandExecutor);
+        setArrowKeyHandler(previousCommandSupplier, nextCommandSupplier);
+        this.commandToHistorySaver = commandToHistorySaver;
+    }
+
+    /**
+     * Sets the action handler for arrow key events. This handler will cycle through
+     * the command history.
+     */
+    private void setArrowKeyHandler(Supplier<String> previousCommandSupplier, Supplier<String> nextCommandSupplier) {
+        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            switch (event.getCode()) {
+            case UP:
+                setNullableUserInput(previousCommandSupplier);
+                event.consume();
+                break;
+            case DOWN:
+                setNullableUserInput(nextCommandSupplier);
+                event.consume();
+                break;
+            default:
+                // let the event pass
+            }
+        });
+    }
+
+    /**
+     * Sets the user input to the given supplier's result if it is not null.
+     *
+     * @param supplier The supplier to get the user input from.
+     */
+    private void setNullableUserInput(Supplier<String> supplier) {
+        String result = supplier.get();
+        if (result == null) {
+            return;
+        }
+        commandTextField.setText(result);
+        commandTextField.positionCaret(result.length());
+    }
+
+    /**
+     * Saves the command to history.
+     *
+     * @param commandText The command text to be saved.
+     */
+    private void saveCommandToHistory(String commandText) {
+        commandToHistorySaver.accept(commandText);
     }
 
     /**
@@ -40,7 +108,7 @@ public class CommandBox extends UiPart<Region> {
         if (commandText.equals("")) {
             return;
         }
-
+        saveCommandToHistory(commandText);
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,7 +1,7 @@
 package seedu.address.ui;
 
-import java.util.function.Supplier;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -15,11 +15,12 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.inputhistory.UserInputHistory;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * The Main Window. Provides the basic application layout containing
- * a menu bar and space where other JavaFX elements can be placed.
+ * The Main Window. Provides the basic application layout containing a menu bar
+ * and space where other JavaFX elements can be placed.
  */
 public class MainWindow extends UiPart<Stage> {
 
@@ -78,6 +79,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination value of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
@@ -85,18 +87,18 @@ public class MainWindow extends UiPart<Stage> {
 
         /*
          * TODO: the code below can be removed once the bug reported here
-         * https://bugs.openjdk.java.net/browse/JDK-8131666
-         * is fixed in later version of SDK.
+         * https://bugs.openjdk.java.net/browse/JDK-8131666 is fixed in later version of
+         * SDK.
          *
          * According to the bug report, TextInputControl (TextField, TextArea) will
          * consume function-key events. Because CommandBox contains a TextField, and
-         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will
-         * not work when the focus is in them because the key event is consumed by
-         * the TextInputControl(s).
+         * ResultDisplay contains a TextArea, thus some accelerators (e.g F1) will not
+         * work when the focus is in them because the key event is consumed by the
+         * TextInputControl(s).
          *
          * For now, we add following event filter to capture such key events and open
-         * help window purposely so to support accelerators even when focus is
-         * in CommandBox or ResultDisplay.
+         * help window purposely so to support accelerators even when focus is in
+         * CommandBox or ResultDisplay.
          */
         getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getTarget() instanceof TextInputControl && keyCombination.match(event)) {
@@ -119,7 +121,9 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        UserInputHistory<String> history = logic.getUserInputHistory();
+        CommandBox commandBox = new CommandBox(this::executeCommand, history::getPreviousChat, history::getNextChat,
+                history::addChatToHistory);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 

--- a/src/test/java/seedu/address/commons/util/QueueUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/QueueUtilTest.java
@@ -1,9 +1,13 @@
 package seedu.address.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class QueueUtilTest {
     private QueueUtil<Integer> queue;

--- a/src/test/java/seedu/address/commons/util/QueueUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/QueueUtilTest.java
@@ -1,0 +1,105 @@
+package seedu.address.commons.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueueUtilTest {
+    private QueueUtil<Integer> queue;
+
+    @BeforeEach
+    void setUp() {
+        queue = new QueueUtil<>(5);
+    }
+
+    @Test
+    void addLast_threeItems_sizeIsThree() {
+        queue.addLast(1);
+        queue.addLast(2);
+        queue.addLast(3);
+        assertEquals(3, queue.size());
+    }
+
+    @Test
+    void addLast_sixItems_onlyFiveItemsRemaining() {
+        queue.addLast(1);
+        queue.addLast(2);
+        queue.addLast(3);
+        queue.addLast(4);
+        queue.addLast(5);
+        queue.addLast(6);
+        assertEquals(5, queue.size());
+        assertEquals(2, queue.get(0));
+    }
+
+    @Test
+    void pollFirst_addThreeItems_itemsOutFifo() {
+        queue.addLast(1);
+        queue.addLast(2);
+        queue.addLast(3);
+        assertEquals(1, queue.pollFirst());
+        assertEquals(2, queue.pollFirst());
+        assertEquals(3, queue.pollFirst());
+        assertNull(queue.pollFirst());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    void get_addThreeItems_correctIndex() {
+        queue.addLast(1);
+        queue.addLast(2);
+        queue.addLast(3);
+        assertEquals(1, queue.get(0));
+        assertEquals(2, queue.get(1));
+        assertEquals(3, queue.get(2));
+        assertThrows(IndexOutOfBoundsException.class, () -> queue.get(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> queue.get(3));
+    }
+
+    @Test
+    void size_addThreeItems_correctSize() {
+        assertEquals(0, queue.size());
+        queue.addLast(1);
+        assertEquals(1, queue.size());
+        queue.addLast(2);
+        assertEquals(2, queue.size());
+        queue.pollFirst();
+        assertEquals(1, queue.size());
+    }
+
+    @Test
+    void traverseUp_tailToHead_correctOrderAndNullReachingHead() {
+        queue.addLast(1);
+        queue.addLast(2);
+        queue.addLast(3);
+        assertEquals(3, queue.traverseUp());
+        assertEquals(2, queue.traverseUp());
+        assertEquals(1, queue.traverseUp());
+        assertEquals(null, queue.traverseUp());
+    }
+
+    @Test
+    void traverseDown_afterTraversingUp_correctOrderAndNull() {
+        queue.addLast(1);
+        queue.addLast(2);
+        queue.addLast(3);
+
+        queue.traverseUp();
+        queue.traverseUp();
+        queue.traverseUp();
+
+        assertEquals(2, queue.traverseDown());
+        assertEquals(3, queue.traverseDown());
+        assertNull(queue.traverseDown());
+    }
+
+    @Test
+    void isEmpty_addItemThenPoll_correctSize() {
+        assertTrue(queue.isEmpty());
+        queue.addLast(1);
+        assertFalse(queue.isEmpty());
+        queue.pollFirst();
+        assertTrue(queue.isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/inputhistory/UserInputHistoryManagerTest.java
+++ b/src/test/java/seedu/address/logic/inputhistory/UserInputHistoryManagerTest.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.inputhistory;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class UserInputHistoryManagerTest {
 

--- a/src/test/java/seedu/address/logic/inputhistory/UserInputHistoryManagerTest.java
+++ b/src/test/java/seedu/address/logic/inputhistory/UserInputHistoryManagerTest.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.inputhistory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserInputHistoryManagerTest {
+
+    private static final String[] CHAT_HISTORY = {"Hello", "World", "How", "Are", "You"};
+    private UserInputHistoryManager history;
+
+    @BeforeEach
+    void setUp() {
+        history = new UserInputHistoryManager();
+    }
+
+    void addInputs() {
+        for (String chat : CHAT_HISTORY) {
+            history.addChatToHistory(chat);
+        }
+    }
+
+    @Test
+    void addChatToHistory() {
+        addInputs();
+        assertEquals(history.size(), CHAT_HISTORY.length);
+        assertTrue(history.hasHistory());
+    }
+
+    @Test
+    void getPreviousChat() {
+        addInputs();
+        for (int i = CHAT_HISTORY.length - 1; i >= 0; i--) {
+            assertEquals(CHAT_HISTORY[i], history.getPreviousChat());
+        }
+        assertNull(history.getPreviousChat());
+    }
+
+    @Test
+    void getNextChat() {
+        addInputs();
+        for (int i = CHAT_HISTORY.length - 1; i >= 0; i--) {
+            history.getPreviousChat();
+        }
+        for (int i = 1; i < CHAT_HISTORY.length; i++) {
+            assertEquals(CHAT_HISTORY[i], history.getNextChat());
+        }
+        assertNull(history.getNextChat());
+    }
+
+    @Test
+    void getPreviousChat_emptyHistory_returnsNull() {
+        assertNull(history.getPreviousChat());
+    }
+
+    @Test
+    void getNextChat_emptyHistory_returnsNull() {
+        assertNull(history.getNextChat());
+    }
+
+    @Test
+    void hasHistory_emptyHistory_returnsFalse() {
+        assertFalse(history.hasHistory());
+    }
+}


### PR DESCRIPTION
This mimics the behavior of a terminal: You can use arrow keys ⬆️ and ⬇️ to navigate to past commands. The user can use this feature when the command box is focused (the behavior is handled in [`CommandBox.java`](https://github.com/bachletuankhai/tp/blob/branch-HistoryArrowNav/src/main/java/seedu/address/ui/CommandBox.java) only).