### PR TITLE
Fix command format in at/ap/as and update product name

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -52,7 +52,7 @@ public class MainApp extends Application {
 
     @Override
     public void init() throws Exception {
-        logger.info("=============================[ Initializing AddressBook ]===========================");
+        logger.info("=============================[ Initializing HackLink ]===========================");
         super.init();
 
         AppParameters appParameters = AppParameters.parse(getParameters());
@@ -73,9 +73,11 @@ public class MainApp extends Application {
     }
 
     /**
-     * Returns a {@code ModelManager} with the data from {@code storage}'s address book and {@code userPrefs}. <br>
-     * The data from the sample address book will be used instead if {@code storage}'s address book is not found,
-     * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
+     * Returns a {@code ModelManager} with the data from {@code storage}'s address
+     * book and {@code userPrefs}. <br>
+     * The data from the sample address book will be used instead if
+     * {@code storage}'s address book is not found, or an empty address book will be
+     * used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
         logger.info("Using data file : " + storage.getAddressBookFilePath());
@@ -91,10 +93,10 @@ public class MainApp extends Application {
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataLoadingException e) {
             logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
-                    + " Will be starting with an empty AddressBook.");
+                    + " Will be starting with an empty data file.");
             initialData = new AddressBook();
         }
-        //read only event book
+        // read only event book
         logger.info("Using data file : " + storage.getEventBookFilePath());
 
         Optional<ReadOnlyEventBook> eventBookOptional;
@@ -149,7 +151,8 @@ public class MainApp extends Application {
             initializedConfig = new Config();
         }
 
-        //Update config file in case it was missing to begin with or there are new/unused fields
+        // Update config file in case it was missing to begin with or there are
+        // new/unused fields
         try {
             ConfigUtil.saveConfig(initializedConfig, configFilePathUsed);
         } catch (IOException e) {
@@ -159,9 +162,9 @@ public class MainApp extends Application {
     }
 
     /**
-     * Returns a {@code UserPrefs} using the file at {@code storage}'s user prefs file path,
-     * or a new {@code UserPrefs} with default configuration if errors occur when
-     * reading from the file.
+     * Returns a {@code UserPrefs} using the file at {@code storage}'s user prefs
+     * file path, or a new {@code UserPrefs} with default configuration if errors
+     * occur when reading from the file.
      */
     protected UserPrefs initPrefs(UserPrefsStorage storage) {
         Path prefsFilePath = storage.getUserPrefsFilePath();
@@ -175,12 +178,13 @@ public class MainApp extends Application {
             }
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
         } catch (DataLoadingException e) {
-            logger.warning("Preference file at " + prefsFilePath + " could not be loaded."
-                    + " Using default preferences.");
+            logger.warning(
+                    "Preference file at " + prefsFilePath + " could not be loaded." + " Using default preferences.");
             initializedPrefs = new UserPrefs();
         }
 
-        //Update prefs file in case it was missing to begin with or there are new/unused fields
+        // Update prefs file in case it was missing to begin with or there are
+        // new/unused fields
         try {
             storage.saveUserPrefs(initializedPrefs);
         } catch (IOException e) {
@@ -192,13 +196,13 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        logger.info("Starting AddressBook " + MainApp.VERSION);
+        logger.info("Starting HackLink " + MainApp.VERSION);
         ui.start(primaryStage);
     }
 
     @Override
     public void stop() {
-        logger.info("============================ [ Stopping Address Book ] =============================");
+        logger.info("============================ [ Stopping HackLink ] =============================");
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {

--- a/src/main/java/seedu/address/commons/core/LogsCenter.java
+++ b/src/main/java/seedu/address/commons/core/LogsCenter.java
@@ -13,14 +13,15 @@ import java.util.logging.SimpleFormatter;
 /**
  * Configures and manages loggers and handlers, including their logging level
  * Named {@link Logger}s can be obtained from this class<br>
- * These loggers have been configured to output messages to the console and a {@code .log} file by default,
- *   at the {@code INFO} level. A new {@code .log} file with a new numbering will be created after the log
- *   file reaches 5MB big, up to a maximum of 5 files.<br>
+ * These loggers have been configured to output messages to the console and a
+ * {@code .log} file by default, at the {@code INFO} level. A new {@code .log}
+ * file with a new numbering will be created after the log file reaches 5MB big,
+ * up to a maximum of 5 files.<br>
  */
 public class LogsCenter {
     private static final int MAX_FILE_COUNT = 5;
     private static final int MAX_FILE_SIZE_IN_BYTES = (int) (Math.pow(2, 20) * 5); // 5MB
-    private static final String LOG_FILE = "addressbook.log";
+    private static final String LOG_FILE = "hacklink.log";
     private static final Logger logger; // logger for this class
     private static Logger baseLogger; // to be used as the parent of all other loggers created by this class.
     private static Level currentLogLevel = Level.INFO;
@@ -32,8 +33,9 @@ public class LogsCenter {
     }
 
     /**
-     * Initializes loggers with the log level specified in the {@code config} object. Applies to all loggers created
-     * using {@link #getLogger(String)} and {@link #getLogger(Class)} methods except for those that are manually set.
+     * Initializes loggers with the log level specified in the {@code config}
+     * object. Applies to all loggers created using {@link #getLogger(String)} and
+     * {@link #getLogger(Class)} methods except for those that are manually set.
      */
     public static void init(Config config) {
         currentLogLevel = config.getLogLevel();
@@ -43,15 +45,20 @@ public class LogsCenter {
     }
 
     /**
-     * Creates a logger with the given name prefixed by the {@code baseLogger}'s name so that the created logger
-     * becomes a descendant of the {@code baseLogger}. Furthermore, the returned logger will have the same log handlers
-     * as the {@code baseLogger}.
+     * Creates a logger with the given name prefixed by the {@code baseLogger}'s
+     * name so that the created logger becomes a descendant of the
+     * {@code baseLogger}. Furthermore, the returned logger will have the same log
+     * handlers as the {@code baseLogger}.
      */
     public static Logger getLogger(String name) {
-        // Java organizes loggers into a hierarchy based on their names (using '.' as a separator, similar to how Java
-        // packages form a hierarchy). Furthermore, loggers without a level inherit the level of their parent logger.
-        // By prefixing names of all loggers with baseLogger's name + ".", we make the baseLogger the parent of all
-        // loggers. This allows us to change the level of all loggers simply by changing the baseLogger level.
+        // Java organizes loggers into a hierarchy based on their names (using '.' as a
+        // separator, similar to how Java
+        // packages form a hierarchy). Furthermore, loggers without a level inherit the
+        // level of their parent logger.
+        // By prefixing names of all loggers with baseLogger's name + ".", we make the
+        // baseLogger the parent of all
+        // loggers. This allows us to change the level of all loggers simply by changing
+        // the baseLogger level.
         Logger logger = Logger.getLogger(baseLogger.getName() + "." + name);
         removeHandlers(logger);
         logger.setUseParentHandlers(true);
@@ -70,20 +77,21 @@ public class LogsCenter {
      * Removes all handlers from the {@code logger}.
      */
     private static void removeHandlers(Logger logger) {
-        Arrays.stream(logger.getHandlers())
-                .forEach(logger::removeHandler);
+        Arrays.stream(logger.getHandlers()).forEach(logger::removeHandler);
     }
 
     /**
-     * Creates a logger named 'ab3', containing a {@code ConsoleHandler} and a {@code FileHandler}.
-     * Sets it as the {@code baseLogger}, to be used as the parent logger of all other loggers.
+     * Creates a logger named 'ab3', containing a {@code ConsoleHandler} and a
+     * {@code FileHandler}. Sets it as the {@code baseLogger}, to be used as the
+     * parent logger of all other loggers.
      */
     private static void setBaseLogger() {
         baseLogger = Logger.getLogger("ab3");
         baseLogger.setUseParentHandlers(false);
         removeHandlers(baseLogger);
 
-        // Level.ALL is used as the level for the handlers because the baseLogger filters the log messages by level
+        // Level.ALL is used as the level for the handlers because the baseLogger
+        // filters the log messages by level
         // already; there is no need to control log message level of the handlers.
 
         // add a ConsoleHandler to log to the console
@@ -101,6 +109,5 @@ public class LogsCenter {
             logger.warning("Error adding file handler for logger.");
         }
     }
-
 
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -26,10 +26,18 @@ public class AddCommand extends Command implements ReversibleCommand {
 
     public static final String COMMAND_WORD = "add";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the contact list. \n"
-            + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_CATEGORY + "CATEGORY " + "[" + PREFIX_GROUP + "GROUP]\n" + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_CATEGORY + "participant " + PREFIX_GROUP + "3 ";
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_CATEGORY + "CATEGORY "
+            + "[" + PREFIX_GROUP + "GROUP]\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe "
+            + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_CATEGORY + "participant "
+            + PREFIX_GROUP + "3 ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_SUCCESS_UNDO = "Person deleted: %1$s";
@@ -50,8 +58,7 @@ public class AddCommand extends Command implements ReversibleCommand {
     }
 
     /**
-     * Creates an AddCommand to add the specified {@code Person} with specified
-     * {@code group}
+     * Creates an AddCommand to add the specified {@code Person} with specified {@code group}
      */
     public AddCommand(Person person, Group group) {
         requireNonNull(person);

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -25,25 +25,17 @@ import seedu.address.model.person.exceptions.GroupSponsorException;
 public class AddCommand extends Command implements ReversibleCommand {
 
     public static final String COMMAND_WORD = "add";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. \n"
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + PREFIX_PHONE + "PHONE "
-            + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_CATEGORY + "CATEGORY "
-            + "[" + PREFIX_GROUP + "GROUP]\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_CATEGORY + "participant "
-            + PREFIX_GROUP + "3 ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the contact list. \n"
+            + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL "
+            + PREFIX_CATEGORY + "CATEGORY " + "[" + PREFIX_GROUP + "GROUP]\n" + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL + "johnd@example.com "
+            + PREFIX_CATEGORY + "participant " + PREFIX_GROUP + "3 ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_SUCCESS_UNDO = "Person deleted: %1$s";
     public static final String MESSAGE_UNDO_NONEXISTENT_PERSON = "Undo failed:"
-            + "Person does not exist in the address book";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+            + "Person does not exist in the contact list";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the contact list";
 
     private final Person toAdd;
     private final Optional<Group> group;
@@ -58,7 +50,8 @@ public class AddCommand extends Command implements ReversibleCommand {
     }
 
     /**
-     * Creates an AddCommand to add the specified {@code Person} with specified {@code group}
+     * Creates an AddCommand to add the specified {@code Person} with specified
+     * {@code group}
      */
     public AddCommand(Person person, Group group) {
         requireNonNull(person);

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,8 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-
+    public static final String MESSAGE_SUCCESS = "Database has been cleared!";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -37,9 +37,14 @@ public class EditCommand extends Command implements ReversibleCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) " + "[" + PREFIX_NAME + "NAME] " + "[" + PREFIX_PHONE
-            + "PHONE] " + "[" + PREFIX_EMAIL + "EMAIL] " + "[" + PREFIX_GROUP + "GROUP]\n" + "Example: "
-            + COMMAND_WORD + " 1 " + PREFIX_PHONE + "91234567 " + PREFIX_EMAIL + "johndoe@example.com";
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_GROUP + "GROUP]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -112,8 +117,8 @@ public class EditCommand extends Command implements ReversibleCommand {
     }
 
     /**
-     * Creates and returns a {@code Person} with the details of {@code personToEdit}
-     * edited with {@code editPersonDescriptor}.
+     * Creates and returns a {@code Person} with the details of {@code personToEdit} edited with
+     * {@code editPersonDescriptor}.
      */
     private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor)
             throws CommandException {
@@ -133,7 +138,7 @@ public class EditCommand extends Command implements ReversibleCommand {
         } else if (editedPerson instanceof Participant) {
             Participant editedParticipant = (Participant) editedPerson;
             Group updatedGroup = editPersonDescriptor.getGroup()
-                    .orElse(new Group(editedParticipant.getGroupNumber()));
+                                                     .orElse(new Group(editedParticipant.getGroupNumber()));
             editedParticipant.setGroupNumber(updatedGroup.getGroupNumber());
             return editedParticipant;
         } else if (editPersonDescriptor.getGroup().isPresent()) {
@@ -162,12 +167,12 @@ public class EditCommand extends Command implements ReversibleCommand {
     @Override
     public String toString() {
         return new ToStringBuilder(this).add("index", index).add("editPersonDescriptor", editPersonDescriptor)
-                .toString();
+                                        .toString();
     }
 
     /**
-     * Stores the details to edit the person with. Each non-empty field value will
-     * replace the corresponding field value of the person.
+     * Stores the details to edit the person with. Each non-empty field value will replace the corresponding field value
+     * of the person.
      */
     public static class EditPersonDescriptor {
         private Name name;
@@ -258,7 +263,7 @@ public class EditCommand extends Command implements ReversibleCommand {
         @Override
         public String toString() {
             return new ToStringBuilder(this).add("name", name).add("phone", phone).add("email", email)
-                    .add("group", group).toString();
+                                            .add("group", group).toString();
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -37,18 +37,13 @@ public class EditCommand extends Command implements ReversibleCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_PHONE + "PHONE] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_GROUP + "GROUP]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + "Parameters: INDEX (must be a positive integer) " + "[" + PREFIX_NAME + "NAME] " + "[" + PREFIX_PHONE
+            + "PHONE] " + "[" + PREFIX_EMAIL + "EMAIL] " + "[" + PREFIX_GROUP + "GROUP]\n" + "Example: "
+            + COMMAND_WORD + " 1 " + PREFIX_PHONE + "91234567 " + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the contact list.";
     public static final String MESSAGE_SPONSOR_HAS_NO_GROUP = "A sponsor doesn't have a group.";
     public static final String MESSAGE_SUCCESS_UNDO = "Changes reverted: %1$s";
 
@@ -137,7 +132,8 @@ public class EditCommand extends Command implements ReversibleCommand {
             return editedStaff;
         } else if (editedPerson instanceof Participant) {
             Participant editedParticipant = (Participant) editedPerson;
-            Group updatedGroup = editPersonDescriptor.getGroup().orElse(new Group(editedParticipant.getGroupNumber()));
+            Group updatedGroup = editPersonDescriptor.getGroup()
+                    .orElse(new Group(editedParticipant.getGroupNumber()));
             editedParticipant.setGroupNumber(updatedGroup.getGroupNumber());
             return editedParticipant;
         } else if (editPersonDescriptor.getGroup().isPresent()) {
@@ -165,9 +161,7 @@ public class EditCommand extends Command implements ReversibleCommand {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .add("index", index)
-                .add("editPersonDescriptor", editPersonDescriptor)
+        return new ToStringBuilder(this).add("index", index).add("editPersonDescriptor", editPersonDescriptor)
                 .toString();
     }
 
@@ -243,7 +237,6 @@ public class EditCommand extends Command implements ReversibleCommand {
             return Optional.ofNullable(group);
         }
 
-
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -264,12 +257,8 @@ public class EditCommand extends Command implements ReversibleCommand {
 
         @Override
         public String toString() {
-            return new ToStringBuilder(this)
-                    .add("name", name)
-                    .add("phone", phone)
-                    .add("email", email)
-                    .add("group", group)
-                    .toString();
+            return new ToStringBuilder(this).add("name", name).add("phone", phone).add("email", email)
+                    .add("group", group).toString();
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting HackLink as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -12,8 +12,8 @@ import seedu.address.model.Model;
 public class RedoCommand extends Command {
     public static final String COMMAND_WORD = "redo";
 
-    public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Redoes the most recent undone command that modifies the address book.";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Redoes the most recent undone command that modifies the database.";
     public static final String MESSAGE_FAILURE_NO_COMMAND_TO_REDO = "There is no command to redo.";
 
     public RedoCommand() {

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -13,8 +13,7 @@ public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-                                               + ": Undoes the most recent command that modifies the address book.\n"
-                                               + "Example: " + COMMAND_WORD;
+            + ": Undoes the most recent command that modifies the database.\n" + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_FAILURE_NO_COMMAND_TO_UNDO = "There's no command to undo.";
 

--- a/src/main/java/seedu/address/logic/parser/alias/AddParticipantAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddParticipantAlias.java
@@ -19,9 +19,9 @@ public class AddParticipantAlias extends Alias<AddCommand> {
     public static final String ALIAS_WORD = "ap";
 
     public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a participant to the address book. \n"
-            + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL \n" + "Example: "
-            + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL
-            + "johndoe@example.com " + "[" + PREFIX_GROUP + "GROUP]\n";
+            + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + "["
+            + PREFIX_GROUP + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE
+            + "98765432 " + PREFIX_EMAIL + "johndoe@example.com ";
 
     private String toAddCommandInput(String input) {
         String paramCategory = PREFIX_CATEGORY + "participant";

--- a/src/main/java/seedu/address/logic/parser/alias/AddParticipantAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddParticipantAlias.java
@@ -18,7 +18,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class AddParticipantAlias extends Alias<AddCommand> {
     public static final String ALIAS_WORD = "ap";
 
-    public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a participant to the address book. \n"
+    public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a participant to the contact list. \n"
             + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + "["
             + PREFIX_GROUP + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE
             + "98765432 " + PREFIX_EMAIL + "johndoe@example.com ";

--- a/src/main/java/seedu/address/logic/parser/alias/AddParticipantAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddParticipantAlias.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.alias;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
@@ -20,7 +21,7 @@ public class AddParticipantAlias extends Alias<AddCommand> {
     public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a participant to the address book. \n"
             + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL \n" + "Example: "
             + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL
-            + "johndoe@example.com";
+            + "johndoe@example.com " + "[" + PREFIX_GROUP + "GROUP]\n";
 
     private String toAddCommandInput(String input) {
         String paramCategory = PREFIX_CATEGORY + "participant";

--- a/src/main/java/seedu/address/logic/parser/alias/AddSponsorAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddSponsorAlias.java
@@ -18,10 +18,10 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class AddSponsorAlias extends Alias<AddCommand> {
     public static final String ALIAS_WORD = "as";
 
-    public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a sponsor to the address book. \n" + "Parameters: "
-            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + "[" + PREFIX_GROUP
-            + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johndoe@example.com";
+    public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a sponsor to the contact list. \n"
+            + "Parameters: " + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + "["
+            + PREFIX_GROUP + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE
+            + "98765432 " + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String TYPE = "sponsor";
 

--- a/src/main/java/seedu/address/logic/parser/alias/AddSponsorAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddSponsorAlias.java
@@ -19,7 +19,7 @@ public class AddSponsorAlias extends Alias<AddCommand> {
     public static final String ALIAS_WORD = "as";
 
     public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a sponsor to the address book. \n" + "Parameters: "
-            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL \n" + "[" + PREFIX_GROUP
+            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + "[" + PREFIX_GROUP
             + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johndoe@example.com";
 

--- a/src/main/java/seedu/address/logic/parser/alias/AddSponsorAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddSponsorAlias.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.alias;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
@@ -18,8 +19,9 @@ public class AddSponsorAlias extends Alias<AddCommand> {
     public static final String ALIAS_WORD = "as";
 
     public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a sponsor to the address book. \n" + "Parameters: "
-            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL \n" + "Example: " + ALIAS_WORD
-            + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL + "johndoe@example.com";
+            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL \n" + "[" + PREFIX_GROUP
+            + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String TYPE = "sponsor";
 

--- a/src/main/java/seedu/address/logic/parser/alias/AddStaffAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddStaffAlias.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.alias;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
@@ -19,8 +20,8 @@ public class AddStaffAlias extends Alias<AddCommand> {
 
     public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a staff to the address book. \n" + "Parameters: "
             + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL \n" + "Example: " + ALIAS_WORD
-            + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL + "johndoe@example.com";
-
+            + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL + "johndoe@example.com " + "["
+            + PREFIX_GROUP + "GROUP]\n";
     public static final String TYPE = "staff";
 
     private String toAddCommandInput(String input) {

--- a/src/main/java/seedu/address/logic/parser/alias/AddStaffAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddStaffAlias.java
@@ -18,7 +18,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class AddStaffAlias extends Alias<AddCommand> {
     public static final String ALIAS_WORD = "at";
 
-    public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a staff to the address book. \n" + "Parameters: "
+    public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a staff to the contact list. \n" + "Parameters: "
             + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + "[" + PREFIX_GROUP
             + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johndoe@example.com ";

--- a/src/main/java/seedu/address/logic/parser/alias/AddStaffAlias.java
+++ b/src/main/java/seedu/address/logic/parser/alias/AddStaffAlias.java
@@ -19,9 +19,9 @@ public class AddStaffAlias extends Alias<AddCommand> {
     public static final String ALIAS_WORD = "at";
 
     public static final String MESSAGE_USAGE = ALIAS_WORD + ": Adds a staff to the address book. \n" + "Parameters: "
-            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL \n" + "Example: " + ALIAS_WORD
-            + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 " + PREFIX_EMAIL + "johndoe@example.com " + "["
-            + PREFIX_GROUP + "GROUP]\n";
+            + PREFIX_NAME + "NAME " + PREFIX_PHONE + "PHONE " + PREFIX_EMAIL + "EMAIL " + "[" + PREFIX_GROUP
+            + "GROUP]\n" + "Example: " + ALIAS_WORD + " " + PREFIX_NAME + "John Doe " + PREFIX_PHONE + "98765432 "
+            + PREFIX_EMAIL + "johndoe@example.com ";
     public static final String TYPE = "staff";
 
     private String toAddCommandInput(String input) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -40,7 +40,7 @@ public class ModelManager implements Model {
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyEventBook eventBook, ReadOnlyUserPrefs userPrefs) {
         requireAllNonNull(addressBook, userPrefs);
 
-        logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
+        logger.fine("Initializing with data file: " + addressBook + " and user prefs " + userPrefs);
 
         this.addressBook = new AddressBook(addressBook);
         this.eventBook = new EventBook(eventBook);
@@ -217,7 +217,6 @@ public class ModelManager implements Model {
         updateFilteredEventList(PREDICATE_SHOW_ALL_EVENTS);
     }
 
-
     @Override
     public void setEvent(Event target, Event editedEvent) {
         requireAllNonNull(target, editedEvent);
@@ -251,11 +250,10 @@ public class ModelManager implements Model {
         requireNonNull(eventBookFilePath);
         userPrefs.setEventBookFilePath(eventBookFilePath);
     }
+
     @Override
     public void setEventBook(ReadOnlyEventBook eventBook) {
         this.eventBook.resetData(eventBook);
     }
-
-
 
 }


### PR DESCRIPTION
- Add optional parameter GROUP in at/ap/as: Fixes #80 
- Fix typo in `at` example: Fixes #77 
- Change product name in log file and error message to HackLink and contact list. This is fixing incorrect terms, as pointed out in the forum. (see nus-cs2103-AY2324S2/forum#775 and nus-cs2103-AY2324S2/forum#752): Fixes #110